### PR TITLE
feat(widget): add `offset()` to `TableState`

### DIFF
--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -392,6 +392,13 @@ impl TableState {
             self.offset = 0;
         }
     }
+
+    /// Returns a copy of the receiver's scroll offset.
+    ///
+    /// This is useful, for example, if you need to "synchronize" the scrolling of a `Table` and a `Paragraph`.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
 }
 
 impl<'a> StatefulWidget for Table<'a> {


### PR DESCRIPTION
> Upstream: [#481](https://github.com/fdehau/tui-rs/pull/481)

## Description
Add simple getter method to `TableState` that returns a copy of its `offset` field.

My motivating case is a program that allows scrolling a `Table` and an adjacent (related) `Paragraph` at the same time

## Testing guidelines
I don't know that any testing is useful here since it only exposes an existing piece of data.

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [ ] I have added relevant tests.
* [x] I have documented all new additions.