### PR TITLE
Significantly improve `Layout` performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,14 @@ keywords = ["tui", "terminal", "dashboard"]
 repository = "https://github.com/fdehau/tui-rs"
 readme = "README.md"
 license = "MIT"
-exclude = ["assets/*", ".github", "Makefile.toml", "CONTRIBUTING.md", "*.log", "tags"]
+exclude = [
+  "assets/*",
+  ".github",
+  "Makefile.toml",
+  "CONTRIBUTING.md",
+  "*.log",
+  "tags",
+]
 autoexamples = true
 edition = "2021"
 
@@ -25,8 +32,9 @@ cassowary = "0.3"
 unicode-segmentation = "1.2"
 unicode-width = "0.1"
 termion = { version = "1.5", optional = true }
+ahash = "*"
 crossterm = { version = "0.22", optional = true }
-serde = { version = "1", optional = true, features = ["derive"]}
+serde = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ cassowary = "0.3"
 unicode-segmentation = "1.2"
 unicode-width = "0.1"
 termion = { version = "1.5", optional = true }
-ahash = "*"
+ahash = "0.7.6"
 crossterm = { version = "0.22", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 

--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -113,10 +113,10 @@ fn draw_charts<B>(f: &mut Frame<B>, app: &mut App, area: Rect)
 where
     B: Backend,
 {
-    let constraints = if app.show_chart {
-        vec![Constraint::Percentage(50), Constraint::Percentage(50)]
+    let constraints: &[Constraint] = if app.show_chart {
+        &[Constraint::Percentage(50), Constraint::Percentage(50)]
     } else {
-        vec![Constraint::Percentage(100)]
+        &[Constraint::Percentage(100)]
     };
     let chunks = Layout::default()
         .constraints(&constraints)

--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -119,7 +119,7 @@ where
         &[Constraint::Percentage(100)]
     };
     let chunks = Layout::default()
-        .constraints(&constraints)
+        .constraints(constraints)
         .direction(Direction::Horizontal)
         .split(area);
     {

--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -119,7 +119,7 @@ where
         vec![Constraint::Percentage(100)]
     };
     let chunks = Layout::default()
-        .constraints(constraints)
+        .constraints(&constraints)
         .direction(Direction::Horizontal)
         .split(area);
     {
@@ -386,7 +386,7 @@ where
 {
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
+        .constraints(&[Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
         .split(area);
     let colors = [
         Color::Reset,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -612,6 +612,12 @@ impl Rect {
 mod tests {
     use super::*;
 
+    const CHUNKS: Layout = Layout::new().direction(Direction::Vertical).constraints(&[
+        Constraint::Percentage(10),
+        Constraint::Max(5),
+        Constraint::Min(1),
+    ]);
+
     #[test]
     fn test_vertical_split_by_height() {
         let target = Rect {
@@ -621,17 +627,7 @@ mod tests {
             height: 10,
         };
 
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(
-                [
-                    Constraint::Percentage(10),
-                    Constraint::Max(5),
-                    Constraint::Min(1),
-                ]
-                .as_ref(),
-            )
-            .split(target);
+        let chunks = CHUNKS.split(target);
 
         assert_eq!(target.height, chunks.iter().map(|r| r.height).sum::<u16>());
         chunks.windows(2).for_each(|w| assert!(w[0].y <= w[1].y));

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -598,6 +598,31 @@ mod tests {
     }
 
     #[test]
+    fn test_vertical_split_by_height_ref() {
+        let target = Rect {
+            x: 2,
+            y: 2,
+            width: 10,
+            height: 10,
+        };
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(
+                [
+                    Constraint::Percentage(10),
+                    Constraint::Max(5),
+                    Constraint::Min(1),
+                ]
+                .as_ref(),
+            )
+            .split_ref(target);
+
+        assert_eq!(target.height, chunks.iter().map(|r| r.height).sum::<u16>());
+        chunks.windows(2).for_each(|w| assert!(w[0].y <= w[1].y));
+    }
+
+    #[test]
     fn test_rect_size_truncation() {
         for width in 256u16..300u16 {
             for height in 256u16..300u16 {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -217,7 +217,7 @@ impl<'a> Layout<'a> {
     ///     });
     /// assert_eq!(
     ///     chunks,
-    ///     vec![
+    ///     &[
     ///         Rect {
     ///             x: 2,
     ///             y: 2,
@@ -244,7 +244,7 @@ impl<'a> Layout<'a> {
     ///     });
     /// assert_eq!(
     ///     chunks,
-    ///     vec![
+    ///     &[
     ///         Rect {
     ///             x: 0,
     ///             y: 0,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -212,7 +212,7 @@ impl<'a> Layout<'a> {
     ///     });
     /// assert_eq!(
     ///     chunks,
-    ///     &vec![
+    ///     vec![
     ///         Rect {
     ///             x: 2,
     ///             y: 2,
@@ -239,7 +239,7 @@ impl<'a> Layout<'a> {
     ///     });
     /// assert_eq!(
     ///     chunks,
-    ///     &vec![
+    ///     vec![
     ///         Rect {
     ///             x: 0,
     ///             y: 0,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -143,13 +143,13 @@ thread_local! {
 impl<'a> Default for Layout<'a> {
     #[inline]
     fn default() -> Layout<'a> {
-        Layout::new()
+        Layout::default()
     }
 }
 
 impl<'a> Layout<'a> {
     #[inline]
-    pub const fn new() -> Layout<'a> {
+    pub const fn default() -> Layout<'a> {
         Layout {
             direction: Direction::Vertical,
             margin: Margin {
@@ -612,11 +612,13 @@ impl Rect {
 mod tests {
     use super::*;
 
-    const CHUNKS: Layout = Layout::new().direction(Direction::Vertical).constraints(&[
-        Constraint::Percentage(10),
-        Constraint::Max(5),
-        Constraint::Min(1),
-    ]);
+    const CHUNKS: Layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(&[
+            Constraint::Percentage(10),
+            Constraint::Max(5),
+            Constraint::Min(1),
+        ]);
 
     #[test]
     fn test_vertical_split_by_height() {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -271,6 +271,51 @@ impl<'a> Layout<'a> {
 
             (vec.as_ptr(), vec.len())
         });
+    // SAFETY: We know 3 things about the vec variable
+    // we are deriving this slice from
+    //
+    // 1. It has the 'static lifetime.
+    //
+    // Because it's stored in a static variable
+    // we also know that our variable has the
+    // 'static lifetime.
+    //
+    // 2. It will never drop.
+    //
+    // Because the split() function produces an owned Vec,
+    // we know that the HashMap will consume it. And because
+    // we never remove any values from the HashMap anywhere
+    // in the code base we know that our data will never be
+    // dropped unless the variable associated with it does
+    // as well. However, Because our variable is static we
+    // know it will never drop
+    //
+    // 3. It will never move
+    //
+    // Because our variable is stored in a static variable
+    // we know it can never be moved
+    //
+    // 
+    // We are returning it as a reference to a slice for 2 reasons
+    //
+    // 1. So it cannot be mutated
+    //
+    // We do not intend for the user to manipulate the 
+    // cache directly, so therefore we must ensure that
+    // our output is immutable.
+    //
+    // 2. So the variable cannot be dropped elsewhere
+    //
+    // Had we returned a Vec generated from Vec::from_raw_parts
+    // we would have to wrap it in a std::mem::ManuallyDrop to
+    // make sure that the Vec wasn't unexpectedly deallocated
+    //
+    //
+    // It is for the reasons that I have stated above that
+    // I believe that the use of this function in this very
+    // specific way will not lead to undefined behaviour or
+    // safety concerns.
+
         unsafe { core::slice::from_raw_parts(vec.0, vec.1) }
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -271,6 +271,7 @@ impl<'a> Layout<'a> {
 
             (vec.as_ptr(), vec.len())
         });
+
     // SAFETY: We know 3 things about the vec variable
     // we are deriving this slice from
     //
@@ -286,7 +287,7 @@ impl<'a> Layout<'a> {
     // we know that the HashMap will consume it. And because
     // we never remove any values from the HashMap anywhere
     // in the code base we know that our data will never be
-    // dropped unless the variable associated with it does
+    // dropped unless the variable associated with it is
     // as well. However, Because our variable is static we
     // know it will never drop
     //
@@ -312,7 +313,8 @@ impl<'a> Layout<'a> {
     //
     //
     // It is for the reasons that I have stated above that
-    // I believe that the use of this function in this very
+    // I believe that the use of the core::slice::from_raw_parts()
+    // function in this very
     // specific way will not lead to undefined behaviour or
     // safety concerns.
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -45,10 +45,13 @@ impl std::hash::Hasher for CustomHash {
     }
 
     #[inline]
-    fn write(&mut self, bytes: &[u8]) {
-        for byte in bytes.iter() {
-            self.0 = self.0.wrapping_shl(8) + (*byte as u64);
-        }
+    fn write(&mut self, _: &[u8]) {
+        panic!("unsupported operation");
+    }
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.0 = i;
     }
 }
 
@@ -87,7 +90,7 @@ const fn min(a: u16, b: u16) -> u16 {
 
 #[inline]
 const fn max(a: u16, b: u16) -> u16 {
-    if a <= b {
+    if a >= b {
         a
     } else {
         b

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -272,51 +272,51 @@ impl<'a> Layout<'a> {
             (vec.as_ptr(), vec.len())
         });
 
-    // SAFETY: We know 3 things about the vec variable
-    // we are deriving this slice from
-    //
-    // 1. It has the 'static lifetime.
-    //
-    // Because it's stored in a static variable
-    // we also know that our variable has the
-    // 'static lifetime.
-    //
-    // 2. It will never drop.
-    //
-    // Because the split() function produces an owned Vec,
-    // we know that the HashMap will consume it. And because
-    // we never remove any values from the HashMap anywhere
-    // in the code base we know that our data will never be
-    // dropped unless the variable associated with it is
-    // as well. However, Because our variable is static we
-    // know it will never drop
-    //
-    // 3. It will never move
-    //
-    // Because our variable is stored in a static variable
-    // we know it can never be moved
-    //
-    // 
-    // We are returning it as a reference to a slice for 2 reasons
-    //
-    // 1. So it cannot be mutated
-    //
-    // We do not intend for the user to manipulate the 
-    // cache directly, so therefore we must ensure that
-    // our output is immutable.
-    //
-    // 2. So the variable cannot be dropped elsewhere
-    //
-    // Had we returned a Vec generated from Vec::from_raw_parts
-    // we would have to wrap it in a std::mem::ManuallyDrop to
-    // make sure that the Vec wasn't unexpectedly deallocated
-    //
-    //
-    // It is for the reasons that I have stated above that
-    // I believe that the use of the core::slice::from_raw_parts()
-    // function in this very
-    // specific way will not lead to undefined behaviour or
-    // safety concerns.
+        // SAFETY: We know 3 things about the vec variable
+        // we are deriving this slice from
+        //
+        // 1. It has the 'static lifetime.
+        //
+        // Because it's stored in a static variable
+        // we also know that our variable has the
+        // 'static lifetime.
+        //
+        // 2. It will never drop.
+        //
+        // Because the split() function produces an owned Vec,
+        // we know that the HashMap will consume it. And because
+        // we never remove any values from the HashMap anywhere
+        // in the code base we know that our data will never be
+        // dropped unless the variable associated with it is
+        // as well. However, Because our variable is static we
+        // know it will never drop
+        //
+        // 3. It will never move
+        //
+        // Because our variable is stored in a static variable
+        // we know it can never be moved
+        //
+        //
+        // We are returning it as a reference to a slice for 2 reasons
+        //
+        // 1. So it cannot be mutated
+        //
+        // We do not intend for the user to manipulate the
+        // cache directly, so therefore we must ensure that
+        // our output is immutable.
+        //
+        // 2. So the variable cannot be dropped elsewhere
+        //
+        // Had we returned a Vec generated from Vec::from_raw_parts
+        // we would have to wrap it in a std::mem::ManuallyDrop to
+        // make sure that the Vec wasn't unexpectedly deallocated
+        //
+        //
+        // It is for the reasons that I have stated above that
+        // I believe that the use of the core::slice::from_raw_parts()
+        // function in this very
+        // specific way will not lead to undefined behaviour or
+        // safety concerns.
 
         unsafe { core::slice::from_raw_parts(vec.0, vec.1) }
     }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -587,29 +587,6 @@ mod tests {
         chunks.windows(2).for_each(|w| assert!(w[0].y <= w[1].y));
     }
 
-    #[bench]
-    fn bench_vertical_split_by_height(b: &mut test::Bencher) {
-        let target = Rect {
-            x: 2,
-            y: 2,
-            width: 10,
-            height: 10,
-        };
-
-        let layout = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(
-                [
-                    Constraint::Percentage(10),
-                    Constraint::Max(5),
-                    Constraint::Min(1),
-                ]
-                .as_ref(),
-            );
-
-        b.iter(|| layout.split(target));
-    }
-
     #[test]
     fn test_rect_size_truncation() {
         for width in 256u16..300u16 {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -263,9 +263,6 @@ impl<'a> Layout<'a> {
 
     pub fn split(&self, area: Rect) -> &'static [Rect] {
         let vec = LAYOUT_CACHE.with(|c| {
-            // SAFETY:
-            // "c" is stored in a static variable
-            // and can therefore have a static lifetime
             let mut b = c.borrow_mut();
 
             let vec = b

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -256,18 +256,16 @@ impl<'a> Layout<'a> {
     /// );
     /// ```
 
-    pub fn split(&self, area: Rect) -> &'static Vec<Rect> {
+    pub fn split(&self, area: Rect) -> Vec<Rect> {
         LAYOUT_CACHE.with(|c| {
             // SAFETY:
             // "c" is stored in a static variable
             // and can therefore have a static lifetime
-            unsafe {
-                std::mem::transmute::<_, &'static Vec<Rect>>(
-                    c.borrow_mut()
-                        .entry(hash_layout!(self, area))
-                        .or_insert_with(|| split(area, self)),
-                )
-            }
+
+            c.borrow_mut()
+                .entry(hash_layout!(self, area))
+                .or_insert_with(|| split(area, self))
+                .clone()
         })
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -547,54 +547,6 @@ mod tests {
         chunks.windows(2).for_each(|w| assert!(w[0].y <= w[1].y));
     }
 
-    #[bench]
-    fn bench_vertical_split_by_height(b: &mut test::Bencher) {
-        let target = Rect {
-            x: 2,
-            y: 2,
-            width: 10,
-            height: 10,
-        };
-
-        b.iter(|| {
-            Layout::default()
-                .direction(Direction::Vertical)
-                .constraints(
-                    [
-                        Constraint::Percentage(10),
-                        Constraint::Max(5),
-                        Constraint::Min(1),
-                    ]
-                    .as_ref(),
-                )
-                .split(target)
-        });
-    }
-
-    #[bench]
-    fn bench_vertical_split_by_height_ref(b: &mut test::Bencher) {
-        let target = Rect {
-            x: 2,
-            y: 2,
-            width: 10,
-            height: 10,
-        };
-
-        b.iter(|| {
-            Layout::default()
-                .direction(Direction::Vertical)
-                .constraints(
-                    [
-                        Constraint::Percentage(10),
-                        Constraint::Max(5),
-                        Constraint::Min(1),
-                    ]
-                    .as_ref(),
-                )
-                .split_ref(target)
-        });
-    }
-
     #[test]
     fn test_rect_size_truncation() {
         for width in 256u16..300u16 {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -212,7 +212,7 @@ impl<'a> Layout<'a> {
     ///     });
     /// assert_eq!(
     ///     chunks,
-    ///     vec![
+    ///     &vec![
     ///         Rect {
     ///             x: 2,
     ///             y: 2,
@@ -239,7 +239,7 @@ impl<'a> Layout<'a> {
     ///     });
     /// assert_eq!(
     ///     chunks,
-    ///     vec![
+    ///     &vec![
     ///         Rect {
     ///             x: 0,
     ///             y: 0,
@@ -256,19 +256,7 @@ impl<'a> Layout<'a> {
     /// );
     /// ```
 
-    pub fn split(&self, area: Rect) -> Vec<Rect> {
-        // TODO: Maybe use a fixed size cache ?
-        LAYOUT_CACHE.with(|c| {
-            c.borrow_mut()
-                .entry(hash_layout!(self, area))
-                .or_insert_with(|| split(area, self))
-                .clone()
-        })
-    }
-
-    /// Much faster than
-
-    pub fn split_ref(&self, area: Rect) -> &'static Vec<Rect> {
+    pub fn split(&self, area: Rect) -> &'static Vec<Rect> {
         LAYOUT_CACHE.with(|c| {
             // SAFETY:
             // "c" is stored in a static variable
@@ -619,32 +607,7 @@ mod tests {
                 .as_ref(),
             );
 
-        b.iter(|| layout.split_ref(target));
-    }
-
-    #[test]
-    fn test_vertical_split_by_height_ref() {
-        let target = Rect {
-            x: 2,
-            y: 2,
-            width: 10,
-            height: 10,
-        };
-
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(
-                [
-                    Constraint::Percentage(10),
-                    Constraint::Max(5),
-                    Constraint::Min(1),
-                ]
-                .as_ref(),
-            )
-            .split_ref(target);
-
-        assert_eq!(target.height, chunks.iter().map(|r| r.height).sum::<u16>());
-        chunks.windows(2).for_each(|w| assert!(w[0].y <= w[1].y));
+        b.iter(|| layout.split(target));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,8 @@
 //! default the computed layout tries to fill the available space completely. So if for any reason
 //! you might need a blank space somewhere, try to pass an additional constraint and don't use the
 //! corresponding area.
+#![feature(test)]
+extern crate test;
 
 pub mod backend;
 pub mod buffer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,8 +160,6 @@
 //! default the computed layout tries to fill the available space completely. So if for any reason
 //! you might need a blank space somewhere, try to pass an additional constraint and don't use the
 //! corresponding area.
-#![feature(test)]
-extern crate test;
 
 pub mod backend;
 pub mod buffer;

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -289,7 +289,8 @@ impl<'a> Table<'a> {
                 y: 0,
                 width: max_width,
                 height: 1,
-            });
+            })
+            .clone();
         if has_selection {
             chunks.remove(0);
         }

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -290,7 +290,7 @@ impl<'a> Table<'a> {
                 width: max_width,
                 height: 1,
             })
-            .clone();
+            .to_vec();
         if has_selection {
             chunks.remove(0);
         }

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -282,7 +282,7 @@ impl<'a> Table<'a> {
         }
         let mut chunks = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints(constraints)
+            .constraints(&constraints)
             .expand_to_fill(false)
             .split(Rect {
                 x: 0,

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -280,7 +280,7 @@ impl<'a> Table<'a> {
         if !self.widths.is_empty() {
             constraints.pop();
         }
-        let mut chunks = Layout::default()
+        let layout = Layout::default()
             .direction(Direction::Horizontal)
             .constraints(&constraints)
             .expand_to_fill(false)
@@ -289,10 +289,12 @@ impl<'a> Table<'a> {
                 y: 0,
                 width: max_width,
                 height: 1,
-            })
-            .to_vec();
+            });
+        let chunks: &[Rect];
         if has_selection {
-            chunks.remove(0);
+            chunks = &layout[1..];
+        } else {
+            chunks = layout;
         }
         chunks.iter().step_by(2).map(|c| c.width).collect()
     }


### PR DESCRIPTION
> Upstream: [#585](https://github.com/fdehau/tui-rs/pull/585)

## Main changes
I found that the current implementation of `Layout` was very heavy on allocations and clones, especially considering you're expected to use it plus the `split()` function every frame. So, I made some changes to allow `Layout` to work more on the stack.

This is what I changed `Layout` to
```rust
#[derive(Debug, Clone, PartialEq, Eq, Hash)]
pub struct Layout<'a> {
    direction: Direction,
    margin: Margin,
    constraints: &'a [Constraint],
    /// Whether the last chunk of the computed layout should be expanded to fill the available
    /// space.
    expand_to_fill: bool,
}
```
This replaces the `constraints` field with a reference to a slice, instead of a `Vec<Constraint>`. Considering that most implementations using `Layout` use static arrays anyway, this seemed like a no brainer, until I tried to use the `LAYOUT_CAHCE`. It is impossible to store this new `Layout` inside of the `LAYOUT_CACHE` because that would require that you borrow the given `Layout` for `'static`. My solution to the problem was only storing the hash of the `Layout` into the cache as opposed to moving the entire `Layout`.
```rust
macro_rules! hash_layout {
    ($self:expr, $area:expr) => {{
        let mut to_hash = ahash::AHasher::default();
        $area.hash(&mut to_hash);
        $self.margin.hash(&mut to_hash);
        $self.expand_to_fill.hash(&mut to_hash);
        $self.direction.hash(&mut to_hash);
        $self.constraints.iter().copied().for_each(|f| match f {
            Constraint::Max(max) => to_hash.write_u16(max),
            Constraint::Min(min) => to_hash.write_u16(min),
            Constraint::Ratio(left, right) => {
                to_hash.write_u32(left);
                to_hash.write_u32(right);
            }
            Constraint::Length(length) => to_hash.write_u16(length),
            Constraint::Percentage(percentage) => to_hash.write_u16(percentage),
        });
        to_hash.finish()
    }};
}

#[derive(Clone, Copy)]
#[repr(transparent)]
struct CustomHash(u64);

impl Default for CustomHash {
    #[inline]
    fn default() -> Self {
        Self(0)
    }
}

impl std::hash::Hasher for CustomHash {
    #[inline]
    fn finish(&self) -> u64 {
        self.0
    }

    #[inline]
    fn write(&mut self, _: &[u8]) {
        panic!("unsupported operation");
    }

    #[inline]
    fn write_u64(&mut self, i: u64) {
        self.0 = i;
    }
}

thread_local! {
    static LAYOUT_CACHE: RefCell<HashMap<u64, Vec<Rect>, BuildHasherDefault<CustomHash>>> = RefCell::new(HashMap::default());
}

pub fn split(&self, area: Rect) -> Vec<Rect> {
    // TODO: Maybe use a fixed size cache ?
    LAYOUT_CACHE.with(|c| {
        c.borrow_mut()
            .entry(hash_layout!(self, area))
            .or_insert_with(|| split(area, self))
            .clone()
    })
}
```
This is the code I used for storing the layout. Here is a breakdown

- First I create a hasher using `ahash`, It's not critical that `ahash` be the hashing algorithm (the default hasher works as well). However, considering how often the `split()` function will be run, I think it's worth the sacrifice of one extra dependency.
- After creating the hasher, I feed it the `area` parameter, and then each field of the `Layout` one by one. `cargo +nightly bench` insisted that this was faster than simply running `self.hash(&mut to_hash);`
- After computing the hash of `area` + `self`, I use the final value as the final key into the `LAYOUT_CAHCE`.
- Because `LAYOUT_CACHE` uses `CustomHash` as it's `RandomState`, the hash computed by `ahash` is simply passed through and no further hashing is done. There's no point in hashing a hash.
- Finally, the resulting `Vec<Rect>` is either grabbed from the `LAYOUT_CACHE` or computed, and then cloned to bypass the reference created by the `HashMap`

## Benchmarks
I did some benchmarks to see just how much my changes effected performance. This was my benchmark
```rust
#[bench]
fn bench_vertical_split_by_height(b: &mut test::Bencher) {
    let target = Rect {
        x: 2,
        y: 2,
        width: 10,
        height: 10,
    };

    let layout = Layout::default()
        .direction(Direction::Vertical)
        .constraints(
            [
                Constraint::Percentage(10),
                Constraint::Max(5),
                Constraint::Min(1),
            ]
            .as_ref(),
        );

    b.iter(|| layout.split(target));
}
```
When I benchmarked the original implementation and mine, these were my results. (top one is my implementation).
```
test layout::tests::bench_vertical_split_by_height ... bench:          89 ns/iter (+/- 5)
test layout::tests::bench_vertical_split_by_height ... bench:         243 ns/iter (+/- 2)
```
My implementation seems to be ~3x faster than the original implementation.

Swapping out `ahash` with the default hasher (`std::collections::hash_map::DefaultHasher::default()`) gave me this result
```
test layout::tests::bench_vertical_split_by_height ... bench:         148 ns/iter (+/- 10)
```

## Smaller changes
I noticed that most of the methods inside of this module (`layout`) were very simple and small, so I made them `const` and `#[inline]`ed them.

## Pre-requisites
All of my changes passed the unit tests and ran the examples.

Thanks for considering my PR,
      - StratusFearMe21