### PR TITLE
fix(widget)!: List should not ignore empty string items

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -293,17 +293,13 @@ impl<'a> Text<'a> {
         T: Into<Cow<'a, str>>,
     {
         let lines: Vec<_> = match content.into() {
+            Cow::Borrowed("") => vec![Spans::from("")],
             Cow::Borrowed(s) => s.lines().map(Spans::from).collect(),
+            Cow::Owned(s) if s.is_empty() => vec![Spans::from("")],
             Cow::Owned(s) => s.lines().map(|l| Spans::from(l.to_owned())).collect(),
         };
 
-        Text {
-            lines: if lines.is_empty() {
-                vec![Spans::from("")]
-            } else {
-                lines
-            },
-        }
+        Text { lines }
     }
 
     /// Create some text (potentially multiple lines) with a style.

--- a/src/text.rs
+++ b/src/text.rs
@@ -298,7 +298,7 @@ impl<'a> Text<'a> {
         };
 
         Text {
-            lines: if lines.len() == 0 {
+            lines: if lines.is_empty() {
                 vec![Spans::from("")]
             } else {
                 lines

--- a/src/text.rs
+++ b/src/text.rs
@@ -292,10 +292,16 @@ impl<'a> Text<'a> {
     where
         T: Into<Cow<'a, str>>,
     {
+        let lines: Vec<_> = match content.into() {
+            Cow::Borrowed(s) => s.lines().map(Spans::from).collect(),
+            Cow::Owned(s) => s.lines().map(|l| Spans::from(l.to_owned())).collect(),
+        };
+
         Text {
-            lines: match content.into() {
-                Cow::Borrowed(s) => s.lines().map(Spans::from).collect(),
-                Cow::Owned(s) => s.lines().map(|l| Spans::from(l.to_owned())).collect(),
+            lines: if lines.len() == 0 {
+                vec![Spans::from("")]
+            } else {
+                lines
             },
         }
     }

--- a/tests/widgets_list.rs
+++ b/tests/widgets_list.rs
@@ -198,3 +198,30 @@ fn widgets_list_should_repeat_highlight_symbol() {
     }
     terminal.backend().assert_buffer(&expected);
 }
+
+#[test]
+fn widget_list_should_not_ignore_empty_string_items() {
+    let backend = TestBackend::new(6, 4);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    terminal
+        .draw(|f| {
+            let items = vec![
+                ListItem::new("Item 1"),
+                ListItem::new(""),
+                ListItem::new(""),
+                ListItem::new("Item 4"),
+            ];
+
+            let list = List::new(items)
+                .style(Style::default())
+                .highlight_style(Style::default());
+
+            f.render_widget(list, f.size());
+        })
+        .unwrap();
+
+    let expected = Buffer::with_lines(vec!["Item 1", "", "", "Item 4"]);
+
+    terminal.backend().assert_buffer(&expected);
+}


### PR DESCRIPTION
> Upstream: [#688](https://github.com/fdehau/tui-rs/pull/688)

## Description
Fixes issue [#680](https://github.com/fdehau/tui-rs/issues/680#issue-1462518032). Handles the case where a list item is created with an empty string, which is not split by the `lines` iterator.

## Testing guidelines
New test can be ran with `cargo test`

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.