### PR TITLE
Bump crossterm to 0.26 with CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,11 @@ jobs:
       matrix:
         rust: ["1.58.1", "stable"]
     steps:
+      # Always install stable for installing cargo-make
       - uses: hecrj/setup-rust-action@967aec96c6a27a0ce15c1dac3aaba332d60565e2
         with:
-          rust-version: ${{ matrix.rust }}
-          components: rustfmt,clippy
-      - uses: actions/checkout@v1
-      - name: "Get cargo bin directory"
-        id: cargo-bin-dir
-        run: echo "::set-output name=dir::$HOME/.cargo/bin"
+          rust-version: stable
+        if: ${{ matrix.rust != 'stable' }}
       - name: "Cache cargo make"
         id: cache-cargo-make
         uses: actions/cache@v2
@@ -35,7 +32,15 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.rust }}-cargo-make-${{ env.CI_CARGO_MAKE_VERSION }}
       - name: "Install cargo-make"
         if: steps.cache-cargo-make.outputs.cache-hit != 'true'
-        run: cargo install cargo-make --version ${{ env.CI_CARGO_MAKE_VERSION }}
+        run: cargo +stable install cargo-make --version ${{ env.CI_CARGO_MAKE_VERSION }}
+      - uses: hecrj/setup-rust-action@967aec96c6a27a0ce15c1dac3aaba332d60565e2
+        with:
+          rust-version: ${{ matrix.rust }}
+          components: rustfmt,clippy
+      - uses: actions/checkout@v1
+      - name: "Get cargo bin directory"
+        id: cargo-bin-dir
+        run: echo "::set-output name=dir::$HOME/.cargo/bin"
       - name: "Format / Build / Test"
         run: cargo make ci
         env:
@@ -48,14 +53,11 @@ jobs:
         rust: ["1.58.1", "stable"]
     steps:
       - uses: actions/checkout@v1
+      # Always install stable for installing cargo-make
       - uses: hecrj/setup-rust-action@967aec96c6a27a0ce15c1dac3aaba332d60565e2
         with:
-          rust-version: ${{ matrix.rust }}
-          components: rustfmt,clippy
-      - uses: actions/checkout@v1
-      - name: "Get cargo bin directory"
-        id: cargo-bin-dir
-        run: echo "::set-output name=dir::$HOME\.cargo\bin"
+          rust-version: stable
+        if: ${{ matrix.rust != 'stable' }}
       - name: "Cache cargo make"
         id: cache-cargo-make
         uses: actions/cache@v2
@@ -64,7 +66,15 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.rust }}-cargo-make-${{ env.CI_CARGO_MAKE_VERSION }}
       - name: "Install cargo-make"
         if: steps.cache-cargo-make.outputs.cache-hit != 'true'
-        run: cargo install cargo-make --version ${{ env.CI_CARGO_MAKE_VERSION }}
+        run: cargo +stable install cargo-make --version ${{ env.CI_CARGO_MAKE_VERSION }}
+      - uses: hecrj/setup-rust-action@967aec96c6a27a0ce15c1dac3aaba332d60565e2
+        with:
+          rust-version: ${{ matrix.rust }}
+          components: rustfmt,clippy
+      - uses: actions/checkout@v1
+      - name: "Get cargo bin directory"
+        id: cargo-bin-dir
+        run: echo "::set-output name=dir::$HOME\.cargo\bin"
       - name: "Format / Build / Test"
         run: cargo make ci
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.56.1", "stable"]
+        rust: ["1.58.1", "stable"]
     steps:
       - uses: hecrj/setup-rust-action@967aec96c6a27a0ce15c1dac3aaba332d60565e2
         with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        rust: ["1.56.1", "stable"]
+        rust: ["1.58.1", "stable"]
     steps:
       - uses: actions/checkout@v1
       - uses: hecrj/setup-rust-action@967aec96c6a27a0ce15c1dac3aaba332d60565e2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cassowary = "0.3"
 unicode-segmentation = "1.2"
 unicode-width = "0.1"
 termion = { version = "1.5", optional = true }
-crossterm = { version = "0.25", optional = true }
+crossterm = { version = "0.26", optional = true }
 serde = { version = "1", optional = true, features = ["derive"]}
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 exclude = ["assets/*", ".github", "Makefile.toml", "CONTRIBUTING.md", "*.log", "tags"]
 autoexamples = true
 edition = "2021"
-rust-version = "1.56.1"
+rust-version = "1.58.1"
 
 [badges]
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ you may rely on the previously cited libraries to achieve such features.
 
 ### Rust version requirements
 
-Since version 0.17.0, `tui` requires **rustc version 1.56.1 or greater**.
+Since version 0.17.0, `tui` requires **rustc version 1.58.1 or greater**.
 
 ### [Documentation](https://docs.rs/tui)
 

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -59,7 +59,7 @@ fn main() -> Result<()> {
     reset_terminal()?;
 
     if let Err(err) = res {
-        println!("{:?}", err);
+        println!("{err:?}");
     }
 
     Ok(())

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -306,7 +306,7 @@ impl Buffer {
         (x_offset as u16, y)
     }
 
-    pub fn set_spans<'a>(&mut self, x: u16, y: u16, spans: &Spans<'a>, width: u16) -> (u16, u16) {
+    pub fn set_spans(&mut self, x: u16, y: u16, spans: &Spans<'_>, width: u16) -> (u16, u16) {
         let mut remaining_width = width;
         let mut x = x;
         for span in &spans.0 {
@@ -327,7 +327,7 @@ impl Buffer {
         (x, y)
     }
 
-    pub fn set_span<'a>(&mut self, x: u16, y: u16, span: &Span<'a>, width: u16) -> (u16, u16) {
+    pub fn set_span(&mut self, x: u16, y: u16, span: &Span<'_>, width: u16) -> (u16, u16) {
         self.set_stringn(x, y, span.content.as_ref(), width as usize, span.style)
     }
 

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -243,11 +243,11 @@ impl<'a> StatefulWidget for List<'a> {
                         list_area.width as usize,
                         item_style,
                     );
-                    (elem_x, (list_area.width - (elem_x - x)) as u16)
+                    (elem_x, (list_area.width - (elem_x - x)))
                 } else {
                     (x, list_area.width)
                 };
-                buf.set_spans(elem_x, y + j as u16, line, max_element_width as u16);
+                buf.set_spans(elem_x, y + j as u16, line, max_element_width);
             }
             if is_selected {
                 buf.set_style(area, self.highlight_style);


### PR DESCRIPTION
> Upstream: [#689](https://github.com/fdehau/tui-rs/pull/689)

## Description
<!--
A clear and concise description of what this PR changes.
-->

## Testing guidelines

I checked all examples by `cargo run --example {example-name}` and confirmed they work on iTerm2 on my Mac machine.

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests. (Since this PR just upgrading existing dependency, no tests need to be added)
* [x] I have documented all new additions.

## Description

[crossterm v0.26.0 was released recently](https://github.com/crossterm-rs/crossterm/releases/tag/0.26). And some people are starting to use the latest version. Since this crate requires crossterm 0.25, both 0.25 and 0.26 are mixed in user's project when the user depends on crossterm directly. I actually saw an issue around this in my tui-textarea project: https://github.com/rhysd/tui-textarea/issues/9

The best way to solve the issue is to follow the latest crossterm version by tui crate. I checked the release note and tui crate. Breaking changes seem not relevant to tui crate.

This is a breaking change due to MSRV bump from 1.56 to 1.58. crossterm 0.26 is using inline format arguments feature and it requires 1.58.