### PR TITLE
chore: update `rust-version` to 1.59 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 exclude = ["assets/*", ".github", "Makefile.toml", "CONTRIBUTING.md", "*.log", "tags"]
 autoexamples = true
 edition = "2021"
-rust-version = "1.56.1"
+rust-version = "1.59.0"
 
 [badges]
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of what this PR changes.
-->

#51 bumped MSRV, but `rust-version` field of Cargo.toml is still 1.56.1.

## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->

Since this only changes the field in Cargo.toml, I checked only `cargo clippy`

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
