### PR TITLE
fix(ci): fix deprecation warnings on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,11 @@ jobs:
           rust-version: ${{ matrix.rust }}
           components: rustfmt,clippy
       - uses: actions/checkout@v1
-      - name: "Get cargo bin directory"
-        id: cargo-bin-dir
-        run: echo "dir=$HOME/.cargo/bin" >> $GITHUB_OUTPUT
       - name: "Cache cargo make"
         id: cache-cargo-make
         uses: actions/cache@v3
         with:
-          path: ${{ steps.cargo-bin-dir.outputs.dir }}/cargo-make
+          path: ~/.cargo/bin/cargo-make
           key: ${{ runner.os }}-${{ matrix.rust }}-cargo-make-${{ env.CI_CARGO_MAKE_VERSION }}
       - name: "Install cargo-make"
         if: steps.cache-cargo-make.outputs.cache-hit != 'true'
@@ -53,14 +50,11 @@ jobs:
           rust-version: ${{ matrix.rust }}
           components: rustfmt,clippy
       - uses: actions/checkout@v1
-      - name: "Get cargo bin directory"
-        id: cargo-bin-dir
-        run: echo "dir=$HOME/.cargo/bin" >> $GITHUB_OUTPUT
       - name: "Cache cargo make"
         id: cache-cargo-make
         uses: actions/cache@v3
         with:
-          path: ${{ steps.cargo-bin-dir.outputs.dir }}\cargo-make.exe
+          path: ~\.cargo\bin\cargo-make.exe
           key: ${{ runner.os }}-${{ matrix.rust }}-cargo-make-${{ env.CI_CARGO_MAKE_VERSION }}
       - name: "Install cargo-make"
         if: steps.cache-cargo-make.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,17 @@ jobs:
       matrix:
         rust: ["1.59.0", "stable"]
     steps:
-      - uses: hecrj/setup-rust-action@967aec96c6a27a0ce15c1dac3aaba332d60565e2
+      - uses: hecrj/setup-rust-action@50a120e4d34903c2c1383dec0e9b1d349a9cc2b1
         with:
           rust-version: ${{ matrix.rust }}
           components: rustfmt,clippy
       - uses: actions/checkout@v1
       - name: "Get cargo bin directory"
         id: cargo-bin-dir
-        run: echo "::set-output name=dir::$HOME/.cargo/bin"
+        run: echo "dir=$HOME/.cargo/bin" >> $GITHUB_OUTPUT
       - name: "Cache cargo make"
         id: cache-cargo-make
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.cargo-bin-dir.outputs.dir }}/cargo-make
           key: ${{ runner.os }}-${{ matrix.rust }}-cargo-make-${{ env.CI_CARGO_MAKE_VERSION }}
@@ -48,17 +48,17 @@ jobs:
         rust: ["1.59.0", "stable"]
     steps:
       - uses: actions/checkout@v1
-      - uses: hecrj/setup-rust-action@967aec96c6a27a0ce15c1dac3aaba332d60565e2
+      - uses: hecrj/setup-rust-action@50a120e4d34903c2c1383dec0e9b1d349a9cc2b1
         with:
           rust-version: ${{ matrix.rust }}
           components: rustfmt,clippy
       - uses: actions/checkout@v1
       - name: "Get cargo bin directory"
         id: cargo-bin-dir
-        run: echo "::set-output name=dir::$HOME\.cargo\bin"
+        run: echo "dir=$HOME/.cargo/bin" >> $GITHUB_OUTPUT
       - name: "Cache cargo make"
         id: cache-cargo-make
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.cargo-bin-dir.outputs.dir }}\cargo-make.exe
           key: ${{ runner.os }}-${{ matrix.rust }}-cargo-make-${{ env.CI_CARGO_MAKE_VERSION }}


### PR DESCRIPTION
## Description
<!--
A clear and concise description of what this PR changes.
-->
Currently CI reports 3 kinds of deprecation warnings:

- Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: hecrj/setup-rust-action@967aec96c6a27a0ce15c1dac3aaba332d60565e2, actions/cache@v2.
- The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files.
- The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files.

This PR fixes all the warnings.

## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->
I checked all warnings are no longer reported on my forked repository: https://github.com/rhysd/tui-rs-revival/actions/runs/4191656530

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
