### PR TITLE
chore(ci): re-enable clippy on CI

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -15,8 +15,8 @@ dependencies = [
     "check-termion",
     "test-crossterm",
     "test-termion",
-    # "clippy-crossterm",  TODO: re-enable
-    # "clippy-termion",  TODO: re-enable
+    "clippy-crossterm",
+    "clippy-termion",
     "test-doc",
 ]
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of what this PR changes.
-->
Fixes #53.
This PR re-enables clippy on CI, which was disabled at #51.

## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->
I confirmed all checks passed in my forked repository: https://github.com/rhysd/tui-rs-revival/actions/runs/4193808784/jobs/7271163234

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
